### PR TITLE
Fix cookbook to install native package rather than deprecated tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Defaults are shown below.
         :tmp_path => '/tmp',
 
         # URL without filename
-        :download_url => 'http://updates.circonus.com/node-agent',
+        :download_url => 'http://updates.circonus.net/node-agent/packages',
 
         # File to download.  nad::install will find an appropriate file if possible.
-        :download_file => "nad-omnibus-20130712T154029Z-rhel5-x86_64.tar.gz",
+        :download_file => "nad-omnibus-20140630T182203Z-1.el6.x86_64.rpm",
 
         # You can also just override the release.  nad::install will find an appropriate release if possible.
-        :release => "20130712T154029Z"
+        :release => "20140630T182203Z"
 
         #-----
         # Daemon Config

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default[:nad][:enabled] = true
 default[:nad][:tmp_path] = '/tmp'
-default[:nad][:download_url] = 'http://updates.circonus.com/node-agent'
+default[:nad][:download_url] = 'http://updates.circonus.net/node-agent/packages'
 
 # recipe nad::install provides a default if you don't override
 default[:nad][:download_file] = nil 


### PR DESCRIPTION
This should address circonus-labs/nad-cookbook#1 by switching to using the native packages that are currently produced.
